### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "express": "^5.1.0",
     "sqlite3": "^5.1.7",
-    "ws": "^8.18.3"
+    "ws": "^8.18.3",
+    "express-rate-limit": "^8.1.0"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,15 @@ const http = require('http');
 const WebSocket = require('ws');
 const path = require('path');
 const { getQuestions } = require('./database');
+const rateLimit = require('express-rate-limit');
+
+// Rate limiter: limit repeated requests to root route.
+const rootLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
 
 const app = express();
 const server = http.createServer(app);
@@ -18,7 +27,7 @@ let timerInterval;
 let playersAnswered = new Set();
 
 // Servir el archivo HTML principal cuando se accede a la ruta raíz.
-app.get('/', (req, res) => {
+app.get('/', rootLimiter, (req, res) => {
     // Asegúrate de que index.html esté en la carpeta principal,
     // fuera de la carpeta 'trivia-server'.
     res.sendFile(path.join(__dirname, '..', 'index.html'));


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Juego-de-Trivia-en-Tiempo-Real/security/code-scanning/2](https://github.com/santiagourdaneta/Juego-de-Trivia-en-Tiempo-Real/security/code-scanning/2)

To fix the detected problem, rate limiting middleware should be added to the route that serves the main HTML file via filesystem access (`GET /`). The standard approach in Express is to use the `express-rate-limit` middleware, which can be installed as an external dependency. 

**How to fix:**  
- Install the `express-rate-limit` package.
- Import `express-rate-limit` in `server/server.js`.
- Create a rate limiter with suitable parameters (e.g., allow 100 requests per 15 minutes).
- Attach the rate limiter as middleware to the route handler for `GET /`.
- No changes to the rest of the application logic.

**Specifically:**  
- Import `express-rate-limit` at the top of `server/server.js`.
- Create a rate limiter instance below the other imports.
- Apply the limiter as a middleware argument to the main page route:  
  `app.get('/', limiter, (req, res) => { ... })`

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
