### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -22,6 +22,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/Juego-de-Trivia-en-Tiempo-Real/security/code-scanning/3](https://github.com/santiagourdaneta/Juego-de-Trivia-en-Tiempo-Real/security/code-scanning/3)

The best way to fix the problem is to add an explicit `permissions` key at the job level (under `build:`), limiting token access to only what is needed. As a minimal starting point, `contents: read` provides sufficient permission for most third-party CI tools and `actions/checkout` to function correctly because it enables the job to check out the repository. Unless Datadog's Synthetics CI GitHub Action requires more than this (which is uncommon), this is appropriate. Place the following immediately below `runs-on: ubuntu-latest` on line 24. Do not change any other functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
